### PR TITLE
Add width: 100% to media-container

### DIFF
--- a/media-player.js
+++ b/media-player.js
@@ -69,6 +69,7 @@ class MediaPlayer extends InternalLocalizeMixin(RtlMixin(LitElement)) {
 				min-height: 11rem;
 				overflow: hidden;
 				position: relative;
+				width: 100%;
 			}
 
 			#d2l-labs-media-player-video {


### PR DESCRIPTION
- Allows the video to stretch if display flex is applied on the media player