### PR TITLE
Change format of @brightspace-ui/core semver

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@brightspace-ui-labs/media-player",
   "description": "A reusable media player component.",
   "repository": "https://github.com/BrightspaceUILabs/media-player.git",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "publishConfig": {
     "access": "public"
   },
@@ -47,7 +47,7 @@
     "require-dir": "^1.2.0"
   },
   "dependencies": {
-    "@brightspace-ui/core": "^1.76.1",
+    "@brightspace-ui/core": "^1",
     "@d2l/seek-bar": "github:Brightspace/d2l-seek-bar#semver:^1",
     "@webcomponents/webcomponentsjs": "^2",
     "lit-element": "^2",


### PR DESCRIPTION
Doing this to avoid conflict when loaded with other components, like sequence viewer.
Otherwise npm loads two different versions of ui core and components get registered twice.