### PR TITLE
Handle relative URLs

### DIFF
--- a/media-player.js
+++ b/media-player.js
@@ -613,10 +613,17 @@ class MediaPlayer extends InternalLocalizeMixin(RtlMixin(LitElement)) {
 		return str.join('');
 	}
 
+	_getAbsoluteUrl(url) {
+		const a = document.createElement('a');
+		a.setAttribute('href', url);
+
+		return a.href;
+	}
+
 	_getDownloadButtonView() {
 		if (!this.allowDownload) return null;
 
-		const url = new Url(this.src);
+		const url = new Url(this._getAbsoluteUrl(this.src));
 		const searchParams = url.searchParams;
 		searchParams.append('attachment', 'true');
 		const linkHref = url.toString();


### PR DESCRIPTION
Media URLs in the Legacy Content Tool are relative.

Ex.
```
/content/course1/sample-video.mp4?d2lSessionVal=IkuWvsshZrwnCEfy5bmvjv346&ou=6609
```

When constructing a [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL) for the download button, you cannot provide only a relative URL string.