### PR TITLE
Fix loading in Safari

### DIFF
--- a/media-player.js
+++ b/media-player.js
@@ -825,12 +825,12 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 	}
 
 	_onLoadedData() {
-		this._loading = false;
-		this._setLoadSuccessMessage();
 		this.dispatchEvent(new CustomEvent('loadeddata'));
 	}
 
 	_onLoadedMetadata($event) {
+		this._loading = false;
+		this._setLoadSuccessMessage();
 		this._duration = $event.target.duration;
 		this.dispatchEvent(new CustomEvent('loadedmetadata'));
 	}


### PR DESCRIPTION
Fixes https://trello.com/c/5QJlSE2s/147-media-player-safari-loading-spinner-does-not-hide-in-lessons-until-you-press-play.

In Safari, `loadeddata` event is not emitted when the media is ready to load. Only once the media is played, does the event get emitted.

Stop displaying loading spinner once the `loadedmetadata` event is emitted.