### PR TITLE
Retry load on error

### DIFF
--- a/media-player.js
+++ b/media-player.js
@@ -668,8 +668,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 	}
 
 	_getMediaAreaView() {
-		if (!this.src) return null;
-		if (this._message.type === MESSAGE_TYPES.error) return null;
+		if (!this.src || this._message.type === MESSAGE_TYPES.error) return null;
 
 		const playIcon = `tier3:${this._playing ? 'pause' : 'play'}`;
 		const playTooltip = `${this._playing ? this.localize('pause') : this.localize('play')} (${KEY_BINDINGS.play})`;

--- a/media-player.js
+++ b/media-player.js
@@ -669,6 +669,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 
 	_getMediaAreaView() {
 		if (!this.src) return null;
+		if (this._message.type === MESSAGE_TYPES.error) return null;
 
 		const playIcon = `tier3:${this._playing ? 'pause' : 'play'}`;
 		const playTooltip = `${this._playing ? this.localize('pause') : this.localize('play')} (${KEY_BINDINGS.play})`;
@@ -701,7 +702,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 						@timeupdate=${this._onTimeUpdate}
 						@volumechange=${this._onVolumeChange}
 					>
-						<source src="${this.src}">
+						<source src="${this.src}" @error=${this._onError}>
 					</video>
 				`;
 			case SOURCE_TYPES.audio:
@@ -723,7 +724,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 						@timeupdate=${this._onTimeUpdate}
 						@volumechange=${this._onVolumeChange}
 					>
-						<source src="${this.src}"></source>
+						<source src="${this.src}" @error=${this._onError}></source>
 					</audio>
 
 					<div id="d2l-labs-media-player-audio-bars-container">


### PR DESCRIPTION
Fix for https://trello.com/c/KeAFPxhi/163-media-player-chrome-nle-content-when-video-file-request-fails-loading-spinner-continues-indefinitely-instead-of-displaying-retry

I'm not sure why this stopped working. I had tested the previous version of the component just a few days ago, and it was working. The `error` event is no longer being emitted by the `<video>`, and I found out that it is the `<source>` element that is really emitting the event.