### PR TITLE
Fix Safari Default Tracks

### DIFF
--- a/media-player.js
+++ b/media-player.js
@@ -1009,11 +1009,18 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 			}
 		});
 
-		setTimeout(() => {
+		// Safari sets the mode of text tracks itself, which have to be overwritten here
+		// It has been observed to happen synchronously, or during the next event loop
+		// Changing the mode in this event loop and the next catches both scenarios
+		// Needs to be caught right away, since the cuechange event can be emitted immediately
+		const setAllDisabled = (() => {
 			for (let i = 0; i < this._media.textTracks.length; i++) {
 				this._media.textTracks[i].mode = 'disabled';
 			}
-		}, 0);
+		}).bind(this);
+
+		setAllDisabled();
+		setTimeout(setAllDisabled, 0);
 	}
 
 	_onTimeUpdate() {


### PR DESCRIPTION
This is a weird one. When programatically adding text tracks to videos, most browsers do not overwrite the initial mode. However, in Safari, this mode is overwritten.

The overwriting either occurs in the current event loop, or the next. So, you must explicitly disable the tracks in the current event loop and the next, to immediately undo Safari's overwriting. This prevents a text track from being displayed before it is selected.