### PR TITLE
ci: adding empty stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ cache:
   npm: false
 jobs:
   include:
+    - stage: Empty Stage (Temporary)
+      script: echo "Empty first stage because visual-diff needs to be 2nd"
     - stage: Visual-difference-tests
       script:
       - if [ $TRAVIS_SECURE_ENV_VARS == true ]; then


### PR DESCRIPTION
For the visual-diff "Regenerate Goldens" button to work, it searched for "Stage 2: Visual-difference-tests" -- which means it can't be the first and only stage. 🤦

This is just a temporary measure until the visual-diff GitHub Action is ready.