### PR TITLE
Save User Preferences in Local Storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,17 @@ The media player supports captions and subtitles, provided as `.srt` or `.vtt` f
 | src | String, required | The URL of the source file.
 | srclang | String, required | The language's code.
 
+## Local Storage
+
+The media player uses local storage to persist the user's playback speed and track selections.
+
+**Items**
+
+| Key | Description |
+| -- | -- |
+| D2L.MediaPlayer.Preferences.Speed | Playback speed that was last selected.
+| D2L.MediaPlayer.Preferences.Track | Identifier for the kind and language of the track that was last selected.
+
 ## Accessibility
 
 The following features are implemented to improve accessibility:

--- a/lang/en.js
+++ b/lang/en.js
@@ -1,5 +1,6 @@
 export default {
 	captions: 'Captions',
+	closedCaptionsAcronym: 'CC',
 	default: 'Default',
 	download: 'Download',
 	exitFullscreen: 'Exit fullscreen',

--- a/media-player.js
+++ b/media-player.js
@@ -713,7 +713,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 	}
 
 	_getKindFromTrackIdentifier(trackIdentifier) {
-		return MediaPlayer._isNullOrUndefined(trackIdentifier) ? null : JSON.parse(trackIdentifier).kind;
+		return !trackIdentifier ? null : JSON.parse(trackIdentifier).kind;
 	}
 
 	_getLoadingSpinnerView() {
@@ -796,7 +796,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 	}
 
 	_getSrclangFromTrackIdentifier(trackIdentifier) {
-		return MediaPlayer._isNullOrUndefined(trackIdentifier) ? null : JSON.parse(trackIdentifier).srclang;
+		return !trackIdentifier ? null : JSON.parse(trackIdentifier).srclang;
 	}
 
 	_getTrackIdentifier(srclang, kind) {
@@ -812,11 +812,11 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 			<d2l-menu-item text="${this.localize('captions')}">
 				<div slot="supporting">${this._selectedTrackLabel}</div>
 				<d2l-menu @d2l-menu-item-change=${this._onTracksMenuItemChange} theme="${ifDefined(theme)}">
-					<d2l-menu-item-radio text="${this.localize('off')}" ?selected="${MediaPlayer._isNullOrUndefined(this._selectedTrackIdentifier)}"></d2l-menu-item-radio>
+					<d2l-menu-item-radio text="${this.localize('off')}" ?selected="${!this._selectedTrackIdentifier}"></d2l-menu-item-radio>
 					${this._tracks.map(track => html`
 						<d2l-menu-item-radio
 							?selected="${this._getTrackIdentifier(track.srclang, track.kind) === this._selectedTrackIdentifier}"
-							text="${`${track.label}${track.kind === TRACK_KINDS.captions ? ' (CC)' : ''}`}"
+							text="${`${track.label}${track.kind === TRACK_KINDS.captions ? ` (${this.localize('closedCaptionsAcronym')})` : ''}`}"
 							value="${this._getTrackIdentifier(track.srclang, track.kind)}"
 						></d2l-menu-item-radio>
 					`)}
@@ -828,10 +828,6 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 	_hidingCustomControls() {
 		const settingsMenuOpened = this._settingsMenu && this._settingsMenu.opened;
 		return this.isIOSVideo || (this._playing && !this._recentlyShowedCustomControls && !this._hoveringMediaControls && !settingsMenuOpened && !this._usingVolumeContainer && this._sourceType === SOURCE_TYPES.video) || this._sourceType === SOURCE_TYPES.unknown;
-	}
-
-	static _isNullOrUndefined(val) {
-		return val === null || val === undefined;
 	}
 
 	_listenForKeyboard(e) {
@@ -1090,12 +1086,8 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 			for (let i = 0; i < this._media.textTracks.length; i++) {
 				const textTrack = this._media.textTracks[i];
 
-				if (!MediaPlayer._isNullOrUndefined(this._selectedTrackIdentifier)) {
-					if (textTrack.language === this._getSrclangFromTrackIdentifier(this._selectedTrackIdentifier) && textTrack.kind === this._getKindFromTrackIdentifier(this._selectedTrackIdentifier)) {
-						textTrack.mode = 'hidden';
-					} else {
-						textTrack.mode = 'disabled';
-					}
+				if (this._selectedTrackIdentifier && textTrack.language === this._getSrclangFromTrackIdentifier(this._selectedTrackIdentifier) && textTrack.kind === this._getKindFromTrackIdentifier(this._selectedTrackIdentifier)) {
+					textTrack.mode = 'hidden';
 				} else {
 					textTrack.mode = 'disabled';
 				}
@@ -1119,7 +1111,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 
 		this._selectedTrackIdentifier = e.target.value;
 
-		if (!MediaPlayer._isNullOrUndefined(this._selectedTrackIdentifier)) localStorage.setItem(PREFERENCES_TRACK_IDENTIFIER_KEY, this._selectedTrackIdentifier);
+		if (this._selectedTrackIdentifier) localStorage.setItem(PREFERENCES_TRACK_IDENTIFIER_KEY, this._selectedTrackIdentifier);
 		else localStorage.removeItem(PREFERENCES_TRACK_IDENTIFIER_KEY);
 
 		for (let i = 0; i < this._media.textTracks.length; i++) {

--- a/media-player.js
+++ b/media-player.js
@@ -37,6 +37,9 @@ const MESSAGE_TYPES = {
 const MIN_TRACK_WIDTH_PX = 250;
 const IS_IOS = /iPad|iPhone|iPod/.test(navigator.platform);
 const PLAYBACK_SPEEDS = ['0.25', '0.5', '0.75', '1.0', '1.25', '1.5', '2.0'];
+const PREFERENCES_KEY_PREFIX = 'D2L.MediaPlayer.Preferences';
+const PREFERENCES_SPEED_KEY = `${PREFERENCES_KEY_PREFIX}.Speed`;
+const PREFERENCES_TRACK_IDENTIFIER_KEY = `${PREFERENCES_KEY_PREFIX}.Track`;
 const SEEK_BAR_UPDATE_PERIOD_MS = 0;
 const SOURCE_TYPES = {
 	audio: 'audio',
@@ -65,12 +68,12 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 			_loading: { type: Boolean, attribute: false },
 			_message: { type: Object, attribute: false },
 			_muted: { type: Boolean, attribute: false },
-			_playbackSpeedMenuValue: { type: String, attribute: false },
 			_playing: { type: Boolean, attribute: false },
 			_recentlyShowedCustomControls: { type: Boolean, attribute: false },
+			_selectedSpeed: { type: String, attribute: false },
+			_selectedTrackIdentifier: { type: String, attribute: false },
 			_sourceType: { type: String, attribute: false },
 			_trackFontSizeRem: { type: Number, attribute: false },
-			_trackMenuValue: { type: String, attribute: false },
 			_tracks: { type: Array, attribute: false },
 			_trackText: { type: String, attribute: false },
 			_usingVolumeContainer: { type: Boolean, attribute: false },
@@ -366,7 +369,6 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 			type: null
 		};
 		this._muted = false;
-		this._playbackSpeedMenuValue = '1.0';
 		this._playing = false;
 		this._recentlyShowedCustomControls = false;
 		this._settingsMenu = null;
@@ -393,8 +395,6 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 		super.firstUpdated(changedProperties);
 
 		if (!this.src) console.warn('d2l-labs-media-player component requires src text');
-
-		this._trackMenuValue = this.localize('off');
 
 		this._mediaContainer = this.shadowRoot.getElementById('d2l-labs-media-player-media-container');
 		this._playButton = this.shadowRoot.getElementById('d2l-labs-media-player-play-button');
@@ -542,10 +542,14 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 						<d2l-dropdown-menu id="d2l-labs-media-player-settings-menu" no-pointer theme="${ifDefined(theme)}">
 							<d2l-menu label="${this.localize('settings')}" theme="${ifDefined(theme)}">
 								<d2l-menu-item id="d2l-labs-media-player-playback-speeds" text="${this.localize('playbackSpeed')}">
-									<div slot="supporting">${this._playbackSpeedMenuValue}</div>
+									<div slot="supporting">${this._selectedSpeed}</div>
 									<d2l-menu @d2l-menu-item-change=${this._onPlaybackSpeedsMenuItemChange} theme="${ifDefined(theme)}">
 										${PLAYBACK_SPEEDS.map(speed => html`
-											<d2l-menu-item-radio text="${speed === '1.0' ? `1.0 (${this.localize('default')})` : speed}" value="${speed}" ?selected="${speed === '1.0'}"></d2l-menu-item-radio>
+											<d2l-menu-item-radio
+												?selected="${speed === this._selectedSpeed}"
+												text="${speed === '1.0' ? `1.0 (${this.localize('default')})` : speed}"
+												value="${speed}"
+											></d2l-menu-item-radio>
 										`)}
 									</d2l-menu>
 								</d2l-menu-item>
@@ -708,6 +712,10 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 		` : null;
 	}
 
+	_getKindFromTrackIdentifier(trackIdentifier) {
+		return MediaPlayer._isNullOrUndefined(trackIdentifier) ? null : JSON.parse(trackIdentifier).kind;
+	}
+
 	_getLoadingSpinnerView() {
 		return this._loading ? html`
 			<div class="d2l-labs-media-player-full-area-centred">
@@ -787,15 +795,30 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 		}
 	}
 
+	_getSrclangFromTrackIdentifier(trackIdentifier) {
+		return MediaPlayer._isNullOrUndefined(trackIdentifier) ? null : JSON.parse(trackIdentifier).srclang;
+	}
+
+	_getTrackIdentifier(srclang, kind) {
+		return JSON.stringify({
+			kind,
+			srclang
+		});
+	}
+
 	_getTracksMenuView() {
 		const theme = this._sourceType === SOURCE_TYPES.video ? 'dark' : undefined;
 		return this._tracks.length > 0 ? html`
 			<d2l-menu-item text="${this.localize('captions')}">
-				<div slot="supporting">${this._trackMenuValue}</div>
+				<div slot="supporting">${this._selectedTrackLabel}</div>
 				<d2l-menu @d2l-menu-item-change=${this._onTracksMenuItemChange} theme="${ifDefined(theme)}">
-					<d2l-menu-item-radio text="${this.localize('off')}" value="${this.localize('off')}" selected></d2l-menu-item-radio>
+					<d2l-menu-item-radio text="${this.localize('off')}" ?selected="${MediaPlayer._isNullOrUndefined(this._selectedTrackIdentifier)}"></d2l-menu-item-radio>
 					${this._tracks.map(track => html`
-						<d2l-menu-item-radio text="${`${track.label}${track.kind === TRACK_KINDS.captions ? ' (CC)' : ''}`}" value="${track.srclang}"></d2l-menu-item-radio>
+						<d2l-menu-item-radio
+							?selected="${this._getTrackIdentifier(track.srclang, track.kind) === this._selectedTrackIdentifier}"
+							text="${`${track.label}${track.kind === TRACK_KINDS.captions ? ' (CC)' : ''}`}"
+							value="${this._getTrackIdentifier(track.srclang, track.kind)}"
+						></d2l-menu-item-radio>
 					`)}
 				</d2l-menu>
 			</d2l-menu-item>
@@ -805,6 +828,10 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 	_hidingCustomControls() {
 		const settingsMenuOpened = this._settingsMenu && this._settingsMenu.opened;
 		return this.isIOSVideo || (this._playing && !this._recentlyShowedCustomControls && !this._hoveringMediaControls && !settingsMenuOpened && !this._usingVolumeContainer && this._sourceType === SOURCE_TYPES.video) || this._sourceType === SOURCE_TYPES.unknown;
+	}
+
+	static _isNullOrUndefined(val) {
+		return val === null || val === undefined;
 	}
 
 	_listenForKeyboard(e) {
@@ -917,6 +944,15 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 	_onLoadedMetadata() {
 		this._loading = false;
 		this._setLoadSuccessMessage();
+
+		if (localStorage.getItem(PREFERENCES_SPEED_KEY)) {
+			this._onPlaybackSpeedsMenuItemChange({
+				target: {
+					value: localStorage.getItem(PREFERENCES_SPEED_KEY)
+				}
+			});
+		}
+
 		this.dispatchEvent(new CustomEvent('loadedmetadata'));
 	}
 
@@ -943,8 +979,10 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 	}
 
 	_onPlaybackSpeedsMenuItemChange(e) {
-		this._media.playbackRate = e.target.value;
-		this._playbackSpeedMenuValue = e.target.value;
+		const speed = e.target.value;
+		this._media.playbackRate = speed;
+		this._selectedSpeed = speed;
+		localStorage.setItem(PREFERENCES_SPEED_KEY, speed);
 	}
 
 	_onPositionChangeSeek() {
@@ -1045,14 +1083,27 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 		// It has been observed to happen synchronously, or during the next event loop
 		// Changing the mode in this event loop and the next catches both scenarios
 		// Needs to be caught right away, since the cuechange event can be emitted immediately
-		const setAllDisabled = (() => {
+		// Set default track to 'hidden'
+		const initializeTracks = (() => {
+			this._selectedTrackIdentifier = localStorage.getItem(PREFERENCES_TRACK_IDENTIFIER_KEY);
+
 			for (let i = 0; i < this._media.textTracks.length; i++) {
-				this._media.textTracks[i].mode = 'disabled';
+				const textTrack = this._media.textTracks[i];
+
+				if (!MediaPlayer._isNullOrUndefined(this._selectedTrackIdentifier)) {
+					if (textTrack.language === this._getSrclangFromTrackIdentifier(this._selectedTrackIdentifier) && textTrack.kind === this._getKindFromTrackIdentifier(this._selectedTrackIdentifier)) {
+						textTrack.mode = 'hidden';
+					} else {
+						textTrack.mode = 'disabled';
+					}
+				} else {
+					textTrack.mode = 'disabled';
+				}
 			}
 		}).bind(this);
 
-		setAllDisabled();
-		setTimeout(setAllDisabled, 0);
+		initializeTracks();
+		setTimeout(initializeTracks, 0);
 	}
 
 	_onTimeUpdate() {
@@ -1064,12 +1115,17 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 	}
 
 	_onTracksMenuItemChange(e) {
-		this._trackMenuValue = e.target.text;
-
 		this._trackText = null;
 
+		this._selectedTrackIdentifier = e.target.value;
+
+		if (!MediaPlayer._isNullOrUndefined(this._selectedTrackIdentifier)) localStorage.setItem(PREFERENCES_TRACK_IDENTIFIER_KEY, this._selectedTrackIdentifier);
+		else localStorage.removeItem(PREFERENCES_TRACK_IDENTIFIER_KEY);
+
 		for (let i = 0; i < this._media.textTracks.length; i++) {
-			if (this._media.textTracks[i].language === e.target.value) {
+			const track = this._media.textTracks[i];
+
+			if (track.language === this._getSrclangFromTrackIdentifier(this._selectedTrackIdentifier) && track.kind === this._getKindFromTrackIdentifier(this._selectedTrackIdentifier)) {
 				this._media.textTracks[i].mode = 'hidden';
 			} else {
 				this._media.textTracks[i].mode = 'disabled';
@@ -1111,6 +1167,16 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 		if (this._volume > 0) {
 			this._muted = false;
 		}
+	}
+
+	get _selectedTrackLabel() {
+		for (let i = 0; i < this._tracks.length; i++) {
+			const track = this._tracks[i];
+
+			if (track.srclang === this._getSrclangFromTrackIdentifier(this._selectedTrackIdentifier) && track.kind === this._getKindFromTrackIdentifier(this._selectedTrackIdentifier)) return track.label;
+		}
+
+		return this.localize('off');
 	}
 
 	_setLoadErrorMessage() {


### PR DESCRIPTION
![store-preferences](https://user-images.githubusercontent.com/24978103/101183926-17bb4600-361e-11eb-80ed-897db3971721.gif)

Stores the user's playback speed and captions selections in local storage. The next time the media player is rendered, it will remember the user's last selections.