### PR TITLE
Use a get byte request instead of the head request.

### DIFF
--- a/media-player.js
+++ b/media-player.js
@@ -637,7 +637,11 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 	}
 
 	async _downloadFromSrc() {
-		const response = await fetch(this.downloadSrc, { method: 'HEAD' });
+		const response = await fetch(this.downloadSrc, {
+			headers: {
+				Range: 'bytes=0-1'
+			}
+		});
 		if (response.status !== 200) {
 			this._message = {
 				text: this.localize('unableToDownload'),


### PR DESCRIPTION
Head request runs into cors issues due to caching.