### PR TITLE
feat: add new property disable-legacy-download and always emit download-requested event when downloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,7 @@ npm install @brightspace-ui-labs/media-player
 | loop | Boolean | false | If set, once the media has finished playing it will replay from the beginning. |
 | poster | String | null | URL of the image to display in place of the media before it has loaded. |
 | src | String, required |  | URL of the media to play. |
-| download-src | String |  | URL of the media to download. |
-| download-ready | Boolean |  | Set dynamically to perform download using `download-src`. |
+| emit-event-to-download | String |  | If set, the component will emit a `download` event to delegate the download function. |
 
 ```
 <!-- Render a media player with a source file and loop the media when it reaches the end -->

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ npm install @brightspace-ui-labs/media-player
 | loop | Boolean | false | If set, once the media has finished playing it will replay from the beginning. |
 | poster | String | null | URL of the image to display in place of the media before it has loaded. |
 | src | String, required |  | URL of the media to play. |
-| emit-event-to-download | String |  | If set, the component will emit a `download` event to delegate the download function. |
+| emit-event-to-download | String |  | If set, the component will emit a `download-requested` event to delegate the download function. |
 
 ```
 <!-- Render a media player with a source file and loop the media when it reaches the end -->

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ npm install @brightspace-ui-labs/media-player
 | poster | String | null | URL of the image to display in place of the media before it has loaded. |
 | src | String, required |  | URL of the media to play. |
 | download-src | String |  | URL of the media to download. |
+| download-ready | Boolean |  | Set dynamically to perform download using `download-src`. |
 
 ```
 <!-- Render a media player with a source file and loop the media when it reaches the end -->

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ npm install @brightspace-ui-labs/media-player
 | loop | Boolean | false | If set, once the media has finished playing it will replay from the beginning. |
 | poster | String | null | URL of the image to display in place of the media before it has loaded. |
 | src | String, required |  | URL of the media to play. |
-| emit-event-to-download | String |  | If set, the component will emit a `download-requested` event to delegate the download function. |
+| disable-legacy-download | String |  | If set, the component will not perform the download. Instead, it'll rely on emitting the `download-requested` event for download.|
 
 ```
 <!-- Render a media player with a source file and loop the media when it reaches the end -->
@@ -109,7 +109,7 @@ this.document.querySelector('d2l-labs-media-player').pause();
 | pause | Dispatched when the media is paused. |
 | timeupdate | Dispatched when the currentTime of the media player has been updated. |
 | trackloaded | Dispatched when a track element has loaded. |
-
+| download-requested | Dispatched when a download is requested. |
 ```
 // Listen for the loadeddata event
 

--- a/media-player.js
+++ b/media-player.js
@@ -65,6 +65,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 			poster: { type: String },
 			src: { type: String },
 			downloadSrc: { type: String, attribute: 'download-src' },
+			downloadReady: { type: Boolean, attribute: 'download-ready', reflect: true },
 			_currentTime: { type: Number, attribute: false },
 			_duration: { type: Number, attribute: false },
 			_loading: { type: Boolean, attribute: false },
@@ -368,6 +369,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 		this.allowDownload = false;
 		this.autoplay = false;
 		this.loop = false;
+		this.downloadReady = false;
 		this._currentTime = 0;
 		this._determiningSourceType = true;
 		this._duration = 1;
@@ -585,6 +587,10 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 		if (changedProperties.has('src')) {
 			this._determineSourceType();
 		}
+
+		if (changedProperties.has('downloadReady') && this.downloadReady) {
+			this._onDownloadButtonPress();
+		}
 	}
 
 	get duration() {
@@ -641,21 +647,8 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 	}
 
 	async _downloadFromSrc() {
-		const response = await fetch(this.downloadSrc, {
-			headers: {
-				Range: 'bytes=0-1'
-			}
-		});
-		if (!response.ok) {
-			this._message = {
-				text: this.localize('unableToDownload'),
-				type: MESSAGE_TYPES.error,
-				hideDownload: true,
-			};
-			return;
-		}
-
-		this._onDownloadButtonPress();
+		this.downloadReady = false;
+		this.dispatchEvent(new CustomEvent('download'));
 	}
 
 	static _formatTime(totalSeconds) {
@@ -753,7 +746,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 						<span>${this._message.text}</span>
 
 						<d2l-button-subtle text="${this.localize('retry')}" @click=${this._onRetryButtonPress}></d2l-button-subtle>
-						${this._message.hideDownload ? '' : html`<d2l-button-subtle text="${this.localize('download')}" @click=${this._onDownloadButtonPress}></d2l-button-subtle>`}
+						<d2l-button-subtle text="${this.localize('download')}" @click=${this._onDownloadButtonPress}></d2l-button-subtle>
 					</div>
 				</d2l-alert>
 			</div>

--- a/media-player.js
+++ b/media-player.js
@@ -641,7 +641,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 	}
 
 	_emitDownloadEvent() {
-		this.dispatchEvent(new CustomEvent('download'));
+		this.dispatchEvent(new CustomEvent('download-requested'));
 	}
 
 	static _formatTime(totalSeconds) {

--- a/media-player.js
+++ b/media-player.js
@@ -64,7 +64,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 			loop: { type: Boolean },
 			poster: { type: String },
 			src: { type: String },
-			emitEventToDownload: { type: Boolean, attribute: 'emit-event-to-download' },
+			disableLegacyDownload: { type: Boolean, attribute: 'disable-legacy-download' },
 			_currentTime: { type: Number, attribute: false },
 			_duration: { type: Number, attribute: false },
 			_loading: { type: Boolean, attribute: false },
@@ -682,15 +682,8 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 	_getDownloadButtonView() {
 		if (!this.allowDownload) return null;
 
-		if (this.emitEventToDownload) {
-			return html`
-				<d2l-menu-item @click=${this._emitDownloadEvent} text="${this.localize('download')}"></d2l-menu-item>
-			`;
-		}
-
-		const linkHref = this._getDownloadLink();
 		return html`
-			<d2l-menu-item-link href="${linkHref}" text="${this.localize('download')}" download></d2l-menu-item-link>
+			<d2l-menu-item @click=${this._onDownloadButtonPress} text="${this.localize('download')}"></d2l-menu-item>
 		`;
 	}
 
@@ -901,17 +894,17 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 	}
 
 	_onDownloadButtonPress() {
-		if (this.emitEventToDownload) {
-			return this._emitDownloadEvent();
+		this._emitDownloadEvent();
+
+		if (!this.disableLegacyDownload) {
+			const linkHref = this._getDownloadLink();
+
+			const anchor = document.createElement('a');
+			anchor.href = linkHref;
+			anchor.download = '';
+			anchor.click();
+			anchor.remove();
 		}
-
-		const linkHref = this._getDownloadLink();
-
-		const anchor = document.createElement('a');
-		anchor.href = linkHref;
-		anchor.download = '';
-		anchor.click();
-		anchor.remove();
 	}
 
 	_onDragEndSeek() {


### PR DESCRIPTION
`disable-legacy-download` to indicate not to use legacy download; instead rely on the event workflow to download.
`download-requested` event is always emitted when downloading.

Related LE PR:
https://github.com/Brightspace/lms/pull/7097