### PR TITLE
feat: add attribute allow-download-on-error

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ npm install @brightspace-ui-labs/media-player
 | loop | Boolean | false | If set, once the media has finished playing it will replay from the beginning. |
 | poster | String | null | URL of the image to display in place of the media before it has loaded. |
 | src | String, required |  | URL of the media to play. |
-| disable-legacy-download | String |  | If set, the component will not perform the download. Instead, it'll rely on emitting the `download-requested` event for download.|
+| allow-download-on-error | Boolean |  | If set, display the download button in the error view. |
 
 ```
 <!-- Render a media player with a source file and loop the media when it reaches the end -->
@@ -109,7 +109,6 @@ this.document.querySelector('d2l-labs-media-player').pause();
 | pause | Dispatched when the media is paused. |
 | timeupdate | Dispatched when the currentTime of the media player has been updated. |
 | trackloaded | Dispatched when a track element has loaded. |
-| download-requested | Dispatched when a download is requested. |
 ```
 // Listen for the loadeddata event
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ npm install @brightspace-ui-labs/media-player
 | poster | String | null | URL of the image to display in place of the media before it has loaded. |
 | src | String, required |  | URL of the media to play. |
 | download-src | String |  | URL of the media to download. |
+| download-ready | Boolean |  | Set dynamically to perform download using `download-src`. |
 
 ```
 <!-- Render a media player with a source file and loop the media when it reaches the end -->

--- a/media-player.js
+++ b/media-player.js
@@ -65,6 +65,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 			poster: { type: String },
 			src: { type: String },
 			downloadSrc: { type: String, attribute: 'download-src' },
+			downloadReady: { type: Boolean, attribute: 'download-ready', reflect: true },
 			_currentTime: { type: Number, attribute: false },
 			_duration: { type: Number, attribute: false },
 			_loading: { type: Boolean, attribute: false },
@@ -368,6 +369,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 		this.allowDownload = false;
 		this.autoplay = false;
 		this.loop = false;
+		this.downloadReady = false;
 		this._currentTime = 0;
 		this._determiningSourceType = true;
 		this._duration = 1;
@@ -585,6 +587,10 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 		if (changedProperties.has('src')) {
 			this._determineSourceType();
 		}
+
+		if (changedProperties.has('downloadReady') && this.downloadReady) {
+			this._onDownloadButtonPress();
+		}
 	}
 
 	get duration() {
@@ -641,21 +647,8 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 	}
 
 	async _downloadFromSrc() {
-		const response = await fetch(this.downloadSrc, {
-			headers: {
-				Range: 'bytes=0-1'
-			}
-		});
-		if (!response.ok) {
-			this._message = {
-				text: this.localize('unableToDownload'),
-				type: MESSAGE_TYPES.error,
-				hideDownload: true,
-			};
-			return;
-		}
-
-		this._onDownloadButtonPress();
+		this.downloadReady = false;
+		this.dispatchEvent(new CustomEvent('download'));
 	}
 
 	static _formatTime(totalSeconds) {
@@ -753,7 +746,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 						<span>${this._message.text}</span>
 
 						<d2l-button-subtle text="${this.localize('retry')}" @click=${this._onRetryButtonPress}></d2l-button-subtle>
-						${this._message.hideDownload ? '' : html`<d2l-button-subtle text="${this.localize('download')}" @click=${this._onDownloadButtonPress}></d2l-button-subtle>`}
+						<d2l-button-subtle text="${this.localize('download')}" @click=${this._onDownloadButtonPress}></d2l-button-subtle>
 					</div>
 				</d2l-alert>
 			</div>

--- a/media-player.js
+++ b/media-player.js
@@ -64,7 +64,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 			loop: { type: Boolean },
 			poster: { type: String },
 			src: { type: String },
-			disableLegacyDownload: { type: Boolean, attribute: 'disable-legacy-download' },
+			allowDownloadOnError: { type: Boolean, attribute: 'allow-download-on-error' },
 			_currentTime: { type: Number, attribute: false },
 			_duration: { type: Number, attribute: false },
 			_loading: { type: Boolean, attribute: false },
@@ -368,7 +368,6 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 		this.allowDownload = false;
 		this.autoplay = false;
 		this.loop = false;
-		this.downloadReady = false;
 		this._currentTime = 0;
 		this._determiningSourceType = true;
 		this._duration = 1;
@@ -568,6 +567,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 								</d2l-menu-item>
 								${this._getTracksMenuView()}
 								${this._getDownloadButtonView()}
+								<slot name="settings-menu-item"></slot>
 							</d2l-menu>
 						</d2l-dropdown-menu>
 					</d2l-dropdown>
@@ -585,10 +585,6 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 
 		if (changedProperties.has('src')) {
 			this._determineSourceType();
-		}
-
-		if (changedProperties.has('downloadReady') && this.downloadReady) {
-			this._onDownloadButtonPress();
 		}
 	}
 
@@ -645,10 +641,6 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 		this._sourceType = SOURCE_TYPES.unknown;
 	}
 
-	_emitDownloadEvent() {
-		this.dispatchEvent(new CustomEvent('download-requested'));
-	}
-
 	static _formatTime(totalSeconds) {
 		totalSeconds = Math.floor(totalSeconds);
 
@@ -687,8 +679,9 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 	_getDownloadButtonView() {
 		if (!this.allowDownload) return null;
 
+		const linkHref = this._getDownloadLink();
 		return html`
-			<d2l-menu-item @d2l-menu-item-select=${this._onDownloadButtonPress} text="${this.localize('download')}"></d2l-menu-item>
+			<d2l-menu-item-link href="${linkHref}" text="${this.localize('download')}" download></d2l-menu-item-link>
 		`;
 	}
 
@@ -733,7 +726,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 						<span>${this._message.text}</span>
 
 						<d2l-button-subtle text="${this.localize('retry')}" @click=${this._onRetryButtonPress}></d2l-button-subtle>
-						<d2l-button-subtle text="${this.localize('download')}" @click=${this._onDownloadButtonPress}></d2l-button-subtle>
+						${this.allowDownloadOnError ? html`<d2l-button-subtle text="${this.localize('download')}" @click=${this._onDownloadButtonPress}></d2l-button-subtle>` : ''}
 					</div>
 				</d2l-alert>
 			</div>
@@ -899,17 +892,13 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 	}
 
 	_onDownloadButtonPress() {
-		this._emitDownloadEvent();
+		const linkHref = this._getDownloadLink();
 
-		if (!this.disableLegacyDownload) {
-			const linkHref = this._getDownloadLink();
-
-			const anchor = document.createElement('a');
-			anchor.href = linkHref;
-			anchor.download = '';
-			anchor.click();
-			anchor.remove();
-		}
+		const anchor = document.createElement('a');
+		anchor.href = linkHref;
+		anchor.download = '';
+		anchor.click();
+		anchor.remove();
 	}
 
 	_onDragEndSeek() {


### PR DESCRIPTION
Add allow-download-on-error attribute to allow download in the error view.
Remove download-requested event workflow.
Also add in a slot for setting menu items.