### PR TITLE
fix: 'trackloaded' event not firing when loading SRT captions files

### DIFF
--- a/media-player.js
+++ b/media-player.js
@@ -1366,6 +1366,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 				track.cues.forEach(cue => {
 					trackElement.addCue(new VTTCue(cue.start, cue.end, cue.text));
 				});
+				this.dispatchEvent(new CustomEvent('trackloaded'));
 
 				this._searchInstances[track.srclang] = new Fuse(track.cues, FUSE_OPTIONS({
 					sortFn: (a, b) => a.start - b.start


### PR DESCRIPTION
Some applications, such as "Audio/Video Note Captions Editor" in the LMS, depend on the 'trackloaded' event to know when to load in certain UI elements.

Because of that, we need to ensure that 'trackloaded' is fired for both SRT and WebVTT files. This PR adds a missing case for SRT.

This fixes the issue in "Audio/Video Note Captions" where the captions editor shows up empty for Audio/Video Notes that use an uploaded SRT file.

![Screen Shot 2021-09-28 at 12 17 34 PM](https://user-images.githubusercontent.com/9592685/135301900-41aa00bb-01dd-4af6-8715-7a3a80c0c26d.png)
