### PR TITLE
feat: Add 'hide-seek-bar' attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ npm install @brightspace-ui-labs/media-player
 | allow-download-on-error | Boolean | false | If set, display the download button in the error view. |
 | autoplay | Boolean | false | If set, will play the media as soon as it has been loaded. |
 | crossorigin | String | null | If set, will set the `crossorigin` attribute on the underlying media element to the set value.
+| hide-seek-bar | Boolean | false | If set, the seek bar will not be shown. |
 | locale | String | en | If set, will display chapter titles in the given locale when possible. |
 | loop | Boolean | false | If set, once the media has finished playing it will replay from the beginning. |
 | metadata | JSON | false | Metadata JSON of the video, contains chapters and cuts data. |

--- a/media-player.js
+++ b/media-player.js
@@ -76,6 +76,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 			allowDownloadOnError: { type: Boolean, attribute: 'allow-download-on-error' },
 			autoplay: { type: Boolean },
 			crossorigin: { type: String },
+			hideSeekBar: { type: Boolean, attribute: 'hide-seek-bar' },
 			locale: { type: String },
 			loop: { type: Boolean },
 			metadata: { type: String },
@@ -704,24 +705,26 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 					${this._getSearchResultsView()}
 					${this._getChapterMarkersView()}
 				</div>
-				<d2l-seek-bar
-					id="d2l-labs-media-player-seek-bar"
-					fullWidth
-					solid
-					value="${Math.floor(this.currentTime / this._duration * 100)}"
-					aria-label="${this.localize('seekSlider')}"
-					aria-orientation="horizontal"
-					aria-valuemin="0"
-					aria-valuemax="100"
-					aria-valuenow="${Math.floor(this.currentTime / this._duration * 100)}"
-					title="${this.localize('seekSlider')}"
-					@drag-start=${this._onDragStartSeek}
-					@drag-end=${this._onDragEndSeek}
-					@position-change=${this._onPositionChangeSeek}
-					@hovering-move=${this._onHoverMove}
-					@hovering-start=${this._onHoverStart}
-					@hovering-end=${this._onHoverEnd}
-				></d2l-seek-bar>
+				${this.hideSeekBar ? '' : html`
+					<d2l-seek-bar
+						id="d2l-labs-media-player-seek-bar"
+						fullWidth
+						solid
+						value="${Math.floor(this.currentTime / this._duration * 100)}"
+						aria-label="${this.localize('seekSlider')}"
+						aria-orientation="horizontal"
+						aria-valuemin="0"
+						aria-valuemax="100"
+						aria-valuenow="${Math.floor(this.currentTime / this._duration * 100)}"
+						title="${this.localize('seekSlider')}"
+						@drag-start=${this._onDragStartSeek}
+						@drag-end=${this._onDragEndSeek}
+						@position-change=${this._onPositionChangeSeek}
+						@hovering-move=${this._onHoverMove}
+						@hovering-start=${this._onHoverStart}
+						@hovering-end=${this._onHoverEnd}
+					></d2l-seek-bar>
+				`}
 				<div id="d2l-labs-media-player-buttons">
 					<d2l-button-icon icon="${playIcon}" text="${playTooltip}"  @click="${this._togglePlay}" theme="${ifDefined(theme)}"></d2l-button-icon>
 


### PR DESCRIPTION
Some consumers of the Media Player, such as Producer X, need an option for hiding the Media Player's seek bar.

<img width="818" alt="Media Player - hide-seek-bar enabled" src="https://user-images.githubusercontent.com/9592685/140179158-d03c019d-ebc3-4ab3-8ab5-5172f9a7a317.png">