### PR TITLE
Support swapping sources on the fly, remove error dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ The media player supports captions and subtitles, provided as `.srt` or `.vtt` f
 
 ## Local Storage
 
-The media player uses local storage to persist the user's playback speed and track selections.
+The media player uses local storage to persist the user's playback speed, track selections, and volume.
 
 **Items**
 
@@ -231,6 +231,7 @@ The media player uses local storage to persist the user's playback speed and tra
 | -- | -- |
 | D2L.MediaPlayer.Preferences.Speed | Playback speed that was last selected.
 | D2L.MediaPlayer.Preferences.Track | Identifier for the kind and language of the track that was last selected.
+| D2L.MediaPlayer.Preferences.Volume | Volume that was last selected.
 
 ## Accessibility
 

--- a/README.md
+++ b/README.md
@@ -24,12 +24,6 @@ A LitElement based media player component, designed for similarity across browse
 > Displaying audio
 ![Example of audio](demo/example-audio.gif)
 
-> Loading media
-![Example of loading](demo/example-loading.gif)
-
-> Media Error
-![Example of error](demo/example-error.png)
-
 ## Installation
 
 To install from NPM:
@@ -52,7 +46,6 @@ npm install @brightspace-ui-labs/media-player
 | Attribute | Type | Default | Description |
 |--|--|--|--|
 | allow-download| Boolean | false | If set, will allow the media to be downloaded.
-| allow-download-on-error | Boolean | false | If set, display the download button in the error view. |
 | autoplay | Boolean | false | If set, will play the media as soon as it has been loaded. |
 | crossorigin | String | null | If set, will set the `crossorigin` attribute on the underlying media element to the set value.
 | hide-seek-bar | Boolean | false | If set, the seek bar will not be shown. |
@@ -143,6 +136,7 @@ The media player supports switching to different qualities. If multiple `<source
 | label | String, required | The label for the track, displayed to the user for selection.
 | src | String, required | The URL of the source file.
 | default | Boolean | false | The source to be selected by default. If no source has the `default` attribute, then the first `<source>` tag is selected by default. Only one default should be set.
+
 ## Showing thumbnails preview with `thumbnails` attribute
 
 Provide a url to the thumbnails sprite image. This sprite is a grid of images taken from the video, at a set interval.
@@ -201,7 +195,6 @@ Example format:
     ]
 }
 ```
-
 
 ## Captions and Subtitles Using `<track>`
 

--- a/media-player.js
+++ b/media-player.js
@@ -489,8 +489,8 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 				display: flex;
 				height: 100%;
 				justify-content: center;
-				position: absolute;
 				left: 0;
+				position: absolute;
 				top: 0;
 				width: 100%;
 				z-index: 2;

--- a/media-player.js
+++ b/media-player.js
@@ -143,9 +143,9 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 				display: block;
 				height: 100%;
 				max-height: 100vh;
+				min-height: 100%;
 				position: relative;
 				width: 100%;
-				min-height: 100%;
 			}
 
 			#d2l-labs-media-player-media-controls {
@@ -489,10 +489,10 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 				display: flex;
 				height: 100%;
 				justify-content: center;
-				width: 100%;
 				position: absolute;
-				top: 0;
 				left: 0;
+				top: 0;
+				width: 100%;
 				z-index: 2;
 			}
 

--- a/media-player.js
+++ b/media-player.js
@@ -110,7 +110,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 		return [ labelStyles, css`
 			:host {
 				display: block;
-				min-height: 300px;
+				min-height: 140px;
 				position: relative;
 			}
 

--- a/media-player.js
+++ b/media-player.js
@@ -566,6 +566,15 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 		this._syncDisplayedTrackTextToSelectedTrack();
 	}
 
+	get volume() {
+		return this._media.volume;
+	}
+
+	set volume(volume) {
+		this._media.volume = volume;
+		this._setPreference(PREFERENCES_VOLUME_KEY, volume);
+	}
+
 	get activeCue() {
 		for (let i = 0; i < this._media.textTracks.length; i++) {
 			if (this._media.textTracks[i].mode === 'hidden') {
@@ -597,15 +606,6 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 
 	get textTracks() {
 		return this._media.textTracks;
-	}
-
-	get volume() {
-		return this._media.volume;
-	}
-
-	set volume(volume) {
-		this._media.volume = volume;
-		this._setPreference(PREFERENCES_VOLUME_KEY, volume);
 	}
 
 	firstUpdated(changedProperties) {
@@ -1440,11 +1440,6 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 		this.dispatchEvent(new CustomEvent('play'));
 	}
 
-	_onPlaying() {
-		this._playing = true;
-		this._pausedForSeekDrag = false;
-	}
-
 	_onPlaybackSpeedsMenuItemChange(e) {
 		const speed = e.target.value;
 		this._media.playbackRate = speed;
@@ -1464,6 +1459,11 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 			event.target.setAttribute('aria-live', 'polite');
 			event.target.removeAttribute('aria-hidden');
 		}
+	}
+
+	_onPlaying() {
+		this._playing = true;
+		this._pausedForSeekDrag = false;
 	}
 
 	_onPositionChangeSeek() {

--- a/media-player.js
+++ b/media-player.js
@@ -1034,7 +1034,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 						@loadeddata=${this._onLoadedData}
 						@play=${this._onPlay}
 						@pause=${this._onPause}
-						@loadedmetadata=${this._onLoadedMetadataVideo}
+						@loadedmetadata=${this._onLoadedMetadata}
 						@timeupdate=${this._onTimeUpdate}
 						@volumechange=${this._onVolumeChange}
 					>
@@ -1056,7 +1056,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 						@loadeddata=${this._onLoadedData}
 						@play=${this._onPlay}
 						@pause=${this._onPause}
-						@loadedmetadata=${this._onLoadedMetadataAudio}
+						@loadedmetadata=${this._onLoadedMetadata}
 						@timeupdate=${this._onTimeUpdate}
 						@volumechange=${this._onVolumeChange}
 					>
@@ -1397,18 +1397,6 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 		});
 
 		this.dispatchEvent(new CustomEvent('loadedmetadata'));
-	}
-
-	_onLoadedMetadataAudio() {
-		if (this._sourceType === SOURCE_TYPES.audio) {
-			this._onLoadedMetadata();
-		}
-	}
-
-	_onLoadedMetadataVideo() {
-		if (this._sourceType === SOURCE_TYPES.video) {
-			this._onLoadedMetadata();
-		}
 	}
 
 	_onPause() {

--- a/media-player.js
+++ b/media-player.js
@@ -588,7 +588,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 	}
 
 	get paused() {
-		return this._media.paused;
+		return this._media && this._media.paused;
 	}
 
 	get sourceType() {
@@ -1048,6 +1048,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 						@error=${this._onError}
 						@loadeddata=${this._onLoadedData}
 						@play=${this._onPlay}
+						@playing=${this._onPlaying}
 						@pause=${this._onPause}
 						@loadedmetadata=${this._onLoadedMetadata}
 						@timeupdate=${this._onTimeUpdate}
@@ -1070,6 +1071,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 						@error=${this._onError}
 						@loadeddata=${this._onLoadedData}
 						@play=${this._onPlay}
+						@playing=${this._onPlaying}
 						@pause=${this._onPause}
 						@loadedmetadata=${this._onLoadedMetadata}
 						@timeupdate=${this._onTimeUpdate}
@@ -1328,8 +1330,9 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 		if (this._seekBar) {
 			this._updateCurrentTimeFromSeekbarProgress();
 
-			if (this._pausedForSeekDrag) this._media.play();
-			this._pausedForSeekDrag = false;
+			if (this._pausedForSeekDrag) {
+				this._media.play();
+			}
 			this._dragging = false;
 		}
 	}
@@ -1430,8 +1433,12 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 	}
 
 	_onPlay() {
-		this._playing = true;
 		this.dispatchEvent(new CustomEvent('play'));
+	}
+
+	_onPlaying() {
+		this._playing = true;
+		this._pausedForSeekDrag = false;
 	}
 
 	_onPlaybackSpeedsMenuItemChange(e) {
@@ -1783,7 +1790,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 			this._maintainHeight = this._media.clientHeight;
 
 			this._stateBeforeLoad = {
-				paused: this.paused,
+				paused: !this._pausedForSeekDrag && this.paused,
 				autoplay: this._media.autoplay,
 				currentTime: this.currentTime
 			};


### PR DESCRIPTION
This adds support for swapping sources on the fly.

Also, when encountering an error loading media, instead of replacing the entire player with an error dialog, it now will just show a loading spinner indefinitely. This is similar to how most video players work. If an error dialog is desired, it should be implemented outside of the player by listening for the error event, hiding the player, and rendering an error dialog.