### PR TITLE
Add thumbnails to the update check and fix thumbnails parsing

### DIFF
--- a/media-player.js
+++ b/media-player.js
@@ -1220,15 +1220,10 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 			`;
 
 		// format of the thumbnail is [url]/tw<width>h<height>i<interval>-<hash>.[png|jpg]
-		// i.e. we want the first 't' character before the last '-'
-		const thumbArr = this.thumbnails.split('-');
-		const imageName = thumbArr[thumbArr.length - 2].toLowerCase();
+		const imageName = this.thumbnails.split('/').pop();
+		if (!imageName) return;
 
-		const thumbMatch = imageName.match(/t[^t]*$/);
-		if (!thumbMatch) {
-			return;
-		}
-		const thumbStr = thumbMatch[0];
+		const thumbStr = imageName.split('-')[0].toLowerCase();
 		const widthMatch = thumbStr.match(/w(\d+)/);
 		const heightMatch = thumbStr.match(/h(\d+)/);
 		const intervalMatch = thumbStr.match(/i(\d+)/);

--- a/media-player.js
+++ b/media-player.js
@@ -1218,7 +1218,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 						html`<span class="d2l-label-text" id="d2l-labs-media-player-thumbnails-preview-chapter" style="bottom: ${DEFAULT_PREVIEW_HEIGHT - 60}px">${chapterTitleLabel}</span>`}
 				</div>
 			`;
-		
+
 		// format of the thumbnail is [url]/tw<width>h<height>i<interval>-<hash>.[png|jpg]
 		// i.e. we want the first 't' character before the last '-'
 		const thumbArr = this.thumbnails.split('-');

--- a/media-player.js
+++ b/media-player.js
@@ -624,11 +624,6 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 		this._searchInput = this.shadowRoot.getElementById('d2l-labs-media-player-search-input');
 		this._searchContainer = this.shadowRoot.getElementById('d2l-labs-media-player-search-container');
 
-		if (this.thumbnails) {
-			this._thumbnailsImage = new Image();
-			this._thumbnailsImage.src = this.thumbnails;
-		}
-
 		this._updateLocale();
 		this._getMetadata();
 

--- a/media-player.js
+++ b/media-player.js
@@ -1220,9 +1220,9 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 			`;
 
 		// format of the thumbnail is [url]/th<height>w<height>i<interval>-<hash>.[png|jpg]
-		const matches = this.thumbnails.match(/th(\d+)w(\d+)i(\d+)[^\/]*$/i);
-		if (matches.length != 4) return; 
-		const [_, thumbHeight, thumbWidth, interval] = matches
+		const matches = this.thumbnails.match(/th(\d+)w(\d+)i(\d+)[^/]*$/i);
+		if (matches.length !== 4) return;
+		const [ , thumbHeight, thumbWidth, interval] = matches;
 
 		const width = this._thumbnailsImage.width;
 		const height = this._thumbnailsImage.height;

--- a/media-player.js
+++ b/media-player.js
@@ -847,6 +847,10 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 		if (changedProperties.has('metadata')) {
 			this._getMetadata();
 		}
+
+		if (changedProperties.has('thumbnails')) {
+			this._getThumbnails();
+		}
 	}
 
 	exitFullscreen() {
@@ -1196,6 +1200,12 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 		return this.mediaType === SOURCE_TYPES.video ? 'dark' : undefined;
 	}
 
+	_getThumbnails() {
+		if (!this.thumbnails) return;
+		this._thumbnailsImage = new Image();
+		this._thumbnailsImage.src = this.thumbnails;
+	}
+
 	_getTimelinePreview() {
 		if (!this._hovering) return;
 		const chapterTitleLabel = this._getChapterTitle();
@@ -1213,8 +1223,17 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 						html`<span class="d2l-label-text" id="d2l-labs-media-player-thumbnails-preview-chapter" style="bottom: ${DEFAULT_PREVIEW_HEIGHT - 60}px">${chapterTitleLabel}</span>`}
 				</div>
 			`;
+		
+		// format of the thumbnail is [url]/tw<width>h<height>i<interval>-<hash>.[png|jpg]
+		// i.e. we want the first 't' character before the last '-'
+		const thumbArr = this.thumbnails.split('-');
+		const imageName = thumbArr[thumbArr.length - 2].toLowerCase();
 
-		const thumbStr = this.thumbnails.split('-')[0].toLowerCase();
+		const thumbMatch = imageName.match(/t[^t]*$/);
+		if (!thumbMatch) {
+			return;
+		}
+		const thumbStr = thumbMatch[0];
 		const widthMatch = thumbStr.match(/w(\d+)/);
 		const heightMatch = thumbStr.match(/h(\d+)/);
 		const intervalMatch = thumbStr.match(/i(\d+)/);

--- a/media-player.js
+++ b/media-player.js
@@ -1219,20 +1219,10 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 				</div>
 			`;
 
-		// format of the thumbnail is [url]/tw<width>h<height>i<interval>-<hash>.[png|jpg]
-		const imageName = this.thumbnails.split('/').pop();
-		if (!imageName) return;
-
-		const thumbStr = imageName.split('-')[0].toLowerCase();
-		const widthMatch = thumbStr.match(/w(\d+)/);
-		const heightMatch = thumbStr.match(/h(\d+)/);
-		const intervalMatch = thumbStr.match(/i(\d+)/);
-
-		if (!intervalMatch) return;
-
-		const interval = parseInt(intervalMatch[1]);
-		const thumbWidth = widthMatch ? parseInt(widthMatch[1]) : DEFAULT_PREVIEW_WIDTH;
-		const thumbHeight = heightMatch ? parseInt(heightMatch[1]) : DEFAULT_PREVIEW_HEIGHT;
+		// format of the thumbnail is [url]/th<height>w<height>i<interval>-<hash>.[png|jpg]
+		const matches = this.thumbnails.match(/th(\d+)w(\d+)i(\d+)[^\/]*$/i);
+		if (matches.length != 4) return; 
+		const [_, thumbHeight, thumbWidth, interval] = matches
 
 		const width = this._thumbnailsImage.width;
 		const height = this._thumbnailsImage.height;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@brightspace-ui-labs/media-player",
   "description": "A reusable media player component.",
   "repository": "https://github.com/BrightspaceUILabs/media-player.git",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Previous thumbnails parsing didn't take into account that the URL can contain hyphens e.g. "http://s3.some-bucket/th160h90i5-hash.png"