### PR TITLE
fix: Fix missing cursor after the initial hide

### DIFF
--- a/media-player.js
+++ b/media-player.js
@@ -666,7 +666,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 
 		const height = this._maintainHeight ? `${this._maintainHeight}px` : (this._heightPixels ? `${this._heightPixels}px` : '100%');
 		const mediaContainerStyle = {
-			cursor: !this._hidingCustomControls() || 'none',
+			cursor: !this._hidingCustomControls() ? 'auto' : 'none',
 			display: 'flex',
 			minHeight: this.isIOSVideo ? 'auto' : '17rem',
 			height,


### PR DESCRIPTION
- Condition was removed in this [commit](https://github.com/BrightspaceUILabs/media-player/commit/feaf5c232e8f5fa0e2339f29b6335fc0084e940c#diff-f5c343271c440fbfdc1a3821d09e2d2f3373202820b0783810b9adb39b24d465L673) accidentally - the cursor would stay hidden in the main container

https://user-images.githubusercontent.com/6110668/144639399-85f6648c-c2fd-4046-a216-037afbca2cb6.mp4
