### PR TITLE
Do not skip the chapters modification if the cut starts at the beginning of the video

### DIFF
--- a/media-player.js
+++ b/media-player.js
@@ -1115,7 +1115,6 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 		// updating the chapter times based on the cuts, loops over all chapters per cut because it can change multiple chapters
 		let cutDiff = 0;
 		for (const cut of data.cuts) {
-			if (!cut.in || cut.in === cut.out) continue;
 			const cutIn = cut.in - cutDiff;
 
 			const newChapters = new Map(); // using map to preserve sort ordering


### PR DESCRIPTION
if cuts.in is 0 - it will evaluate it to be falsey.
cuts should never have the same values for cut.in and cut.out. if something - we need to catch it in the content service and not in the player
issue: https://trello.com/c/glM0dAyC/237-media-player-chapters-arent-displayed-at-the-right-time-in-the-seekbar-when-the-beginning-of-the-video-is-cut