### PR TITLE
fix: Fix volume icon when dragging to 0

### DIFF
--- a/media-player.js
+++ b/media-player.js
@@ -1791,10 +1791,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 
 	_onVolumeChange() {
 		this._volume = this.volume;
-
-		if (this._volume > 0) {
-			this._muted = false;
-		}
+		this._muted = this._volume === 0;
 	}
 
 	_parseSourceNode(node, index) {
@@ -1917,7 +1914,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 
 	_toggleMute() {
 		if (this._muted) {
-			this.volume = this.preMuteVolume;
+			this.volume = this.preMuteVolume || 1;
 		} else {
 			this.preMuteVolume = this.volume;
 			this.volume = 0;


### PR DESCRIPTION
- Previously, icon would remain as unmuted when volume changed to 0 - now it updates correctly
- If the saved volume is 0, set the premute volume to max (1)

https://user-images.githubusercontent.com/6110668/145886331-c85a1dbc-3bd5-4b48-a8d3-89aa47b1fceb.mp4


https://user-images.githubusercontent.com/6110668/145886340-ee41394b-306c-48f0-95d1-0e646326fe38.mov
