### PR TITLE
Fix to issue where switching to another source that's already expired causes strange behaviour

### DIFF
--- a/media-player.js
+++ b/media-player.js
@@ -1849,11 +1849,13 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 				// the video object from resizing temporarily
 				this._maintainHeight = this._media.clientHeight;
 
-				this._stateBeforeLoad = {
-					paused: !this._pausedForSeekDrag && this.paused && !this._playRequested,
-					autoplay: this._media.autoplay,
-					currentTime: this.currentTime
-				};
+				if (!this._stateBeforeLoad) {
+					this._stateBeforeLoad = {
+						paused: !this._pausedForSeekDrag && this.paused && !this._playRequested,
+						autoplay: this._media.autoplay,
+						currentTime: this.currentTime
+					};
+				}
 
 				this.pause();
 				this.load();


### PR DESCRIPTION
Example: if you switch to SD and it's already expired, it will fail to load it and the state in the player will become paused and the current time will get reset to zero. This change will make it so that it only "remembers" the state the first time it's set (i.e. when first trying to switch to SD) and not after the failure. The state is reset after a successful load, so it should "remember" the state again on the next reload.