### PR TITLE
Lit 2 Upgrade: breaking changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@brightspace-ui/core": "^2",
-    "@d2l/seek-bar": "github:Brightspace/d2l-seek-bar#semver:^1",
+    "@d2l/seek-bar": "github:Brightspace/d2l-seek-bar#semver:^2",
     "fuse.js": "^6.4.6",
     "lit-element": "^3",
     "lit-html": "^2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@babel/core": "^7",
     "@babel/eslint-parser": "^7",
     "@brightspace-ui/stylelint-config": "^0.3",
-    "@open-wc/testing": "^2",
+    "@open-wc/testing": "^3",
     "@web/dev-server": "^0.1",
     "@web/test-runner": "^0.13",
     "@web/test-runner-saucelabs": "^0.6",
@@ -44,10 +44,11 @@
     "stylelint": "^14"
   },
   "dependencies": {
-    "@brightspace-ui/core": "^1",
+    "@brightspace-ui/core": "^2",
     "@d2l/seek-bar": "github:Brightspace/d2l-seek-bar#semver:^1",
     "fuse.js": "^6.4.6",
-    "lit-element": "^2",
+    "lit-element": "^3",
+    "lit-html": "^2",
     "lodash-es": "^4.17.21",
     "parse-srt": "^1.0.0-alpha",
     "resize-observer-polyfill": "^1",


### PR DESCRIPTION
This PR makes the breaking changes required to update to Lit 2 (`lit-html` 2 and `lit-element` 3). The Lit 2 upgrade will be a coordinated effort, so **this PR should not merge at this time**.

Breaking change checklist: 
- [x] Update `lit-html` -> `^2`, `lit-element` -> `^3`, `open-wc/testing` -> `^3` (if used)
- [x] `createRenderRoot` usages -> move from LitElement to ReactiveElement 
- [x] Remove Dependabot Lit rules
- [x] Bump any dependencies to their Lit 2 versions
- [x] Remove any manual lifecycle calls to Lit 1 reactive controllers
- [x] Backwards-compatible changes merged: #159

Renamed API's:
- [x] `UpdatingElement` -> `ReactiveElement`
- [x] `@internalProperty` -> `@state` (we don't use TypeScript decorators)
- [x] `static getStyles()` -> `static finalizeStyles(styles)`
- [x] `_getUpdateComplete()` -> `getUpdateComplete()`
- [x] `NodePart` -> `ChildPart`

Testing checklist: 
- [x] CI/ unit tests pass
- [x] Local testing on demo pages
- [ ] Testing component in the LMS

For more information on the Lit 2 upgrade, visit https://lit.dev/docs/releases/upgrade/ or contact team Gaudi.