### PR TITLE
Add duration change event

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ this.document.querySelector('d2l-labs-media-player').pause();
 | Event | Description |
 |--|--|
 | cuechange | Dispatched when the currently-displayed captions cue changes. |
+| durationchange | Dispatched when the video or media displayed has changed its duration |
 | ended | Dispatched when the media has reached the end of its duration. |
 | error | Dispatched when the media failed to load. |
 | loadeddata | Dispatched when the media at the current playback position has finished loading. Often the first frame. |

--- a/media-player.js
+++ b/media-player.js
@@ -1458,6 +1458,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalLocalizeMixin(RtlMix
 
 	_onDurationChange(e) {
 		this._duration = e.target.duration;
+		this.dispatchEvent(new CustomEvent('durationchange'));
 	}
 
 	_onEnded() {


### PR DESCRIPTION
See: https://github.com/Brightspace/content-components/pull/259
This event is necessary for updating the timeline at the right time. Sometimes, the timeline appears to be zoomed because the duration is by default set to 1.
<img width="1147" alt="Screen Shot 2022-03-25 at 2 14 39 PM" src="https://user-images.githubusercontent.com/98043376/160178304-f9ace6d3-4b64-4940-95fe-1ab56163cf67.png">
as opposed to this
<img width="1152" alt="Screen Shot 2022-03-25 at 2 15 29 PM" src="https://user-images.githubusercontent.com/98043376/160178452-7dc4cef2-612e-4254-ae32-a855f1f10ea8.png">

