### PR TITLE
replace br tags when seeking, update demo

### DIFF
--- a/demo/sample-srt-fr.srt
+++ b/demo/sample-srt-fr.srt
@@ -5,3 +5,9 @@
 2
 00:00:02.500 --> 00:00:04.500
 (Voix indistinctes)
+
+3
+00:00:05.000 --> 00:00:09.500
+Ligne un
+Ligne deux
+Ligne trois

--- a/demo/sample-vtt-en.vtt
+++ b/demo/sample-vtt-en.vtt
@@ -1,7 +1,9 @@
 WEBVTT
 
 00:00:00.500 --> 00:00:04.000
-So we decided we had to put in a new well
+So we decided
+we had to put
+in a new well
 
 NOTE This is a comment, and should not be displayed
 

--- a/media-player.js
+++ b/media-player.js
@@ -1873,10 +1873,6 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalDynamicLocalizeMixin
 		return quality;
 	}
 
-	_sanitizeText(text) {
-		return text.replace(/<br \/>/g, '\n');
-	}
-
 	_reloadSource() {
 		if (this._media) {
 			const oldSourceNode = this._media.getElementsByTagName('source')[0];
@@ -1917,6 +1913,10 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalDynamicLocalizeMixin
 				this.load();
 			}
 		}
+	}
+
+	_sanitizeText(text) {
+		return text.replace(/<br \/>/g, '\n');
 	}
 
 	_setPreference(preferenceKey, value) {

--- a/media-player.js
+++ b/media-player.js
@@ -1408,7 +1408,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalDynamicLocalizeMixin
 		for (let i = 0; i < this._media.textTracks.length; i++) {
 			if (this._media.textTracks[i].mode === 'hidden') {
 				if (this._media.textTracks[i].activeCues.length > 0) {
-					this._trackText = this._media.textTracks[i].activeCues[0].text.replace(/<br \/>/g, '\n');
+					this._trackText = this._sanitizeText(this._media.textTracks[i].activeCues[0].text);
 				} else this._trackText = null;
 
 				this.dispatchEvent(new CustomEvent('cuechange'));
@@ -1873,6 +1873,10 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalDynamicLocalizeMixin
 		return quality;
 	}
 
+	_sanitizeText(text) {
+		return text.replace(/<br \/>/g, '\n');
+	}
+
 	_reloadSource() {
 		if (this._media) {
 			const oldSourceNode = this._media.getElementsByTagName('source')[0];
@@ -1974,7 +1978,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalDynamicLocalizeMixin
 				(cue.startTime <= this.currentTime) &&
 				(cue.endTime >= this.currentTime)
 			) {
-				this._trackText = cue.text;
+				this._trackText = this._sanitizeText(cue.text);
 				this.dispatchEvent(new CustomEvent('cuechange'));
 			}
 		}


### PR DESCRIPTION
Fixed another issue where we weren't replacing br tags when seeking to a spot in the video where the currently active cue would still be active.