### PR TITLE
feat: Allow consumers to override the max-height of the video player

### DIFF
--- a/media-player.js
+++ b/media-player.js
@@ -24,7 +24,7 @@ import { InternalDynamicLocalizeMixin } from './src/mixins/internal-dynamic-loca
 import { labelStyles } from '@brightspace-ui/core/components/typography/styles.js';
 import parseSRT from 'parse-srt/src/parse-srt.js';
 import ResizeObserver from 'resize-observer-polyfill';
-import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin';
+import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { styleMap } from 'lit-html/directives/style-map.js';
 
 const DEFAULT_SPEED = '1.0';

--- a/media-player.js
+++ b/media-player.js
@@ -155,7 +155,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalDynamicLocalizeMixin
 			#d2l-labs-media-player-video {
 				display: block;
 				height: 100%;
-				max-height: 100vh;
+				max-height: var(--d2l-labs-media-player-video-max-height, 100vh);
 				min-height: 100%;
 				position: relative;
 				width: 100%;

--- a/src/mixins/internal-dynamic-localize-mixin.js
+++ b/src/mixins/internal-dynamic-localize-mixin.js
@@ -1,5 +1,5 @@
 import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
-import { LocalizeDynamicMixin } from '@brightspace-ui/core/mixins/localize-dynamic-mixin';
+import { LocalizeDynamicMixin } from '@brightspace-ui/core/mixins/localize-dynamic-mixin.js';
 
 const InternalDynamicLocalizeMixinClass = superClass => class extends LocalizeDynamicMixin(superClass) {
 	static get localizeConfig() {


### PR DESCRIPTION
## Description
There's currently no way for consumers to adjust the max height of the video player.

If there's a better way to achieve this goal, I'm open to other approaches. 

## Overview of changes
- allow consumers to override the `max-height` of the video player
  - using a css variable (`--d2l-labs-media-player-video-max-height`)
- Add some missing `.js` extensions to imports