### PR TITLE
Hide captions when transcript viewer is on

### DIFF
--- a/media-player.js
+++ b/media-player.js
@@ -901,7 +901,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalDynamicLocalizeMixin
 			${this._getMediaAreaView()}
 
 			${this.isIOSVideo ? null : html`
-				${!this._trackText ? null : html`
+				${!this._trackText || this.transcriptViewerOn ? null : html`
 				<div id="d2l-labs-media-player-track-container" style=${styleMap(trackContainerStyle)} @click=${this._onTrackContainerClick}>
 					<div>
 						<span style=${styleMap(trackSpanStyle)} role="status">${this._trackText}</span>

--- a/media-player.js
+++ b/media-player.js
@@ -635,7 +635,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalDynamicLocalizeMixin
 				overflow-y: auto;
 				position: absolute;
 				right: 0;
-				top: 40px;
+				top: 50px;
 				width: 65%;
 				z-index: 1;
 			}
@@ -645,7 +645,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalDynamicLocalizeMixin
 				overflow-y: auto;
 				position: absolute;
 				right: 0;
-				top: 40px;
+				top: 45px;
 				width: 100%;
 				z-index: 1;
 			}

--- a/media-player.js
+++ b/media-player.js
@@ -631,21 +631,21 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalDynamicLocalizeMixin
 			}
 			#video-transcript-viewer {
 				color: white;
-				height: 75%;
 				overflow-y: auto;
 				position: absolute;
 				right: 0;
 				top: 40px;
+				bottom: 55px;
 				width: 65%;
 				z-index: 1;
 			}
 			#audio-transcript-viewer {
 				color: black;
-				height: 75%;
 				overflow-y: auto;
 				position: absolute;
 				right: 0;
 				top: 40px;
+				bottom: 60px;
 				width: 100%;
 				z-index: 1;
 			}
@@ -1398,7 +1398,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalDynamicLocalizeMixin
 					>
 						<source @error=${this._onError}></source>
 					</audio>
-
+					${this.transcriptViewerOn ? null : html`
 					<div id="d2l-labs-media-player-audio-bars-container">
 						<div id="d2l-labs-media-player-audio-play-button-container">
 							<button id="d2l-labs-media-player-audio-play-button" title="${playTooltip}" aria-label="${playTooltip}" @click=${this._togglePlay}>
@@ -1407,7 +1407,7 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalDynamicLocalizeMixin
 						</div>
 
 						<d2l-labs-media-player-audio-bars ?playing="${this._playing}"></d2l-labs-media-player-audio-bars>
-					</div>
+					</div>`}
 				`;
 			default:
 				return null;

--- a/media-player.js
+++ b/media-player.js
@@ -630,22 +630,22 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalDynamicLocalizeMixin
 				box-shadow: -5px 0 0 black;
 			}
 			#video-transcript-viewer {
+				bottom: 55px;
 				color: white;
 				overflow-y: auto;
 				position: absolute;
 				right: 0;
 				top: 40px;
-				bottom: 55px;
 				width: 65%;
 				z-index: 1;
 			}
 			#audio-transcript-viewer {
+				bottom: 60px;
 				color: black;
 				overflow-y: auto;
 				position: absolute;
 				right: 0;
 				top: 40px;
-				bottom: 60px;
 				width: 100%;
 				z-index: 1;
 			}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "A reusable media player component.",
   "type": "module",
   "repository": "https://github.com/BrightspaceUILabs/media-player.git",
-  "version": "3.5.2",
+  "version": "3.5.3",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Fixes Safari issue where captions would re-appear while transcript viewer is on