### PR TITLE
Undo changes related to code artifact and match-lms-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,11 @@
+
 name: Release
 on:
   push:
-    branches: [main, 'release/**']
+    branches:
+      - main
+      - '[0-9]+.x'
+      - '[0-9]+.[0-9]+.x'
 jobs:
   release:
     name: Release
@@ -16,20 +20,9 @@ jobs:
         uses: Brightspace/third-party-actions@actions/setup-node
         with:
           node-version-file: .nvmrc
-      - name: Add CodeArtifact npm registry
-        uses: Brightspace/codeartifact-actions/npm/add-registry@main
+      - name: Semantic Release
+        uses: BrightspaceUI/actions/semantic-release@main
         with:
-          auth-token: ${{ secrets.CODEARTIFACT_AUTH_TOKEN }}
-      - name: Get CodeArtifact Authorization Token
-        uses: Brightspace/codeartifact-actions/get-authorization-token@main
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
-      - name: Match LMS Release
-        uses: Brightspace/lms-version-actions/match-lms-release@main
-        with:
-          RALLY_API_KEY: ${{ secrets.RALLY_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}
           NPM: true
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,16 @@ jobs:
         uses: Brightspace/third-party-actions@actions/setup-node
         with:
           node-version-file: .nvmrc
+      - name: Add CodeArtifact npm registry
+        uses: Brightspace/codeartifact-actions/npm/add-registry@main
+        with:
+          auth-token: ${{ secrets.CODEARTIFACT_AUTH_TOKEN }}
+      - name: Get CodeArtifact Authorization Token
+        uses: Brightspace/codeartifact-actions/get-authorization-token@main
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
       - name: Match LMS Release
         uses: Brightspace/lms-version-actions/match-lms-release@main
         with:

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@brightspace-ui-labs/media-player",
+  "name": "@d2l/labs-media-player",
   "description": "A reusable media player component.",
   "type": "module",
   "repository": "https://github.com/BrightspaceUILabs/media-player.git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "https://github.com/BrightspaceUILabs/media-player.git",
   "version": "2023.1.2",
   "publishConfig": {
-    "access": "public"
+    "registry": "https://d2l-569998014834.d.codeartifact.us-east-1.amazonaws.com/npm/private/"
   },
   "files": [
     "media-player-menu-item.js",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@d2l/media-player",
+  "name": "@brightspace-ui-labs/media-player",
   "description": "A reusable media player component.",
   "type": "module",
   "repository": "https://github.com/BrightspaceUILabs/media-player.git",
-  "version": "2023.1.2",
+  "version": "3.5.13",
   "publishConfig": {
-    "registry": "https://d2l-569998014834.d.codeartifact.us-east-1.amazonaws.com/npm/private/"
+    "access": "public"
   },
   "files": [
     "media-player-menu-item.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@d2l/labs-media-player",
+  "name": "@d2l/media-player",
   "description": "A reusable media player component.",
   "type": "module",
   "repository": "https://github.com/BrightspaceUILabs/media-player.git",


### PR DESCRIPTION
From what I understand about code artifact packages, they need to be prefixed with @d2l/ so I went with what other private BrightspaceUILabs repos were doing and prefixed the title with @d2l/labs-media-player. Let me know if this works.