### PR TITLE
add back isf cut off fix

### DIFF
--- a/media-player.js
+++ b/media-player.js
@@ -140,6 +140,8 @@ class MediaPlayer extends FocusVisiblePolyfillMixin(InternalDynamicLocalizeMixin
 			#d2l-labs-media-player-media-container {
 				align-items: center;
 				justify-content: center;
+				/* This max-height prevents the video from growing out of bounds and appearing cut off inside of ISF iframes */
+				max-height: 100vh;
 				overflow: hidden;
 				position: relative;
 				width: 100%;


### PR DESCRIPTION
Removed this fix with the layout slider removal but it is still needed because aspect-ratio is still being set on the media container div. Adding it back prevents videos from being cut off in ISF when the aspect ratio doesn't match the dimensions of the iframe. Need to keep aspect-ratio because transcript viewer relies on it to maintain the size of the player when switching between views.