### PR TITLE
fix: remove .focus-visible CSS class

### DIFF
--- a/media-player.js
+++ b/media-player.js
@@ -398,7 +398,6 @@ class MediaPlayer extends InternalDynamicLocalizeMixin(RtlMixin(LitElement)) {
 				cursor: pointer;
 			}
 
-			#d2l-labs-media-player-audio-play-button.focus-visible,
 			#d2l-labs-media-player-audio-play-button:${unsafeCSS(getFocusPseudoClass())} {
 				border: 2px solid var(--d2l-color-celestine);
 			}


### PR DESCRIPTION
Hi there, Gaudi again!

We've changed our approach (yet again) to handling :focus-visible. We've simplified things further, and are no longer going to add the .focus-visible CSS class as a fallback as it just isn't necessary. Instead, we'll just rely on the existing getFocusPseudoClass() helper.