### PR TITLE
Support downloading when the source url is a blob

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ npm install @brightspace-ui-labs/media-player
 | allow-download| Boolean | false | If set, will allow the media to be downloaded.
 | autoplay | Boolean | false | If set, will play the media as soon as it has been loaded. |
 | crossorigin | String | null | If set, will set the `crossorigin` attribute on the underlying media element to the set value.
+| download-filename | String | null | If set along with `allow-download`, will use the provided value as the base of the filename (the extension will be automatically appended)
 | duration-hint | Number | 1 | Measured in seconds. If set and the duration cannot be determined automatically, this value will be used instead.
 | hide-captions-selection | Boolean | false | If set, the menu item to configure captions is hidden. |
 | hide-seek-bar | Boolean | false | If set, the seek bar will not be shown. |

--- a/media-player.js
+++ b/media-player.js
@@ -85,6 +85,7 @@ class MediaPlayer extends InternalDynamicLocalizeMixin(RtlMixin(LitElement)) {
 			allowDownload: { type: Boolean, attribute: 'allow-download', reflect: true },
 			autoplay: { type: Boolean },
 			crossorigin: { type: String },
+			downloadFilename: { type: String, attribute: 'download-filename' },
 			durationHint: { type: Number, attribute: 'duration-hint' },
 			hideCaptionsSelection: { type: Boolean, attribute: 'hide-captions-selection' },
 			hideSeekBar: { type: Boolean, attribute: 'hide-seek-bar' },
@@ -1174,12 +1175,16 @@ class MediaPlayer extends InternalDynamicLocalizeMixin(RtlMixin(LitElement)) {
 
 		const linkHref = this._getDownloadLink();
 		return html`
-			<d2l-menu-item-link href="${linkHref}" text="${this.localize('download')}" download></d2l-menu-item-link>
+			<d2l-menu-item-link href="${linkHref}" text="${this.localize('download')}" download=${this.downloadFilename}></d2l-menu-item-link>
 		`;
 	}
 
 	_getDownloadLink() {
 		const srcUrl = this._getCurrentSource();
+		if (srcUrl.startsWith('blob:')) {
+			return srcUrl;
+		}
+
 		// Due to Ionic rewriter bug we need to use '_' as a first query string parameter
 		const attachmentUrl = `${srcUrl}${srcUrl && srcUrl.indexOf('?') === -1 ? '?_' : ''}`;
 		const url = new Url(this._getAbsoluteUrl(attachmentUrl));


### PR DESCRIPTION
Adding download-filename to give the blob a meaningful name.

For context, this is to support downloading a web capture before it gets uploaded. I.e. the file only exists as a blob at that point.