### PR TITLE
feat: Dispatch events for content consumption tracking (US156167)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ this.document.querySelector('d2l-labs-media-player').pause();
 | loadedmetadata | Dispatched when the metadata for the media has finished loading. |
 | play | Dispatched when the media begins playing. |
 | pause | Dispatched when the media is paused. |
+| seeked | Dispatched when the user finishes navigating through the media's timeline using the seek bar. |
+| seeking | Dispatched when the user starts navigating through the media's timeline using the seek bar. |
 | timeupdate | Dispatched when the currentTime of the media player has been updated. |
 | trackloaded | Dispatched when a track element has loaded. |
 | trackloadfailed | Dispatched when a track element could not be loaded from the provided src attribute. |

--- a/media-player.js
+++ b/media-player.js
@@ -1561,6 +1561,8 @@ class MediaPlayer extends InternalDynamicLocalizeMixin(RtlMixin(LitElement)) {
 			}
 			this._dragging = false;
 		}
+
+		this.dispatchEvent(new CustomEvent('seeked'));
 	}
 
 	_onDragStartSeek() {
@@ -1573,6 +1575,8 @@ class MediaPlayer extends InternalDynamicLocalizeMixin(RtlMixin(LitElement)) {
 		setTimeout(() => {
 			this._updateCurrentTimeFromSeekbarProgress();
 		}, 0);
+
+		this.dispatchEvent(new CustomEvent('seeking'));
 	}
 
 	_onDragStartVolume() {


### PR DESCRIPTION
In order to keep track of which segments of an audio file are being consumed by the user, we need to know when the user skips to a different segment using the seekbar.

For this reason, this PR makes the Media Player dispatch `seeking` and `seeked` events that `<d2l-content-media-player>` can listen to.