### PR TITLE
Make Media Player accessibility compliant

### DIFF
--- a/lang/en.js
+++ b/lang/en.js
@@ -17,6 +17,7 @@ export default {
 	"pause": "Pause",
 	"play": "Play",
 	"playbackSpeed": "Playback speed",
+	'playButton': "Play Button",
 	"retry": "Retry",
 	"showSearchInput": "Show search input",
 	"searchPlaceholder": "Search...",

--- a/lang/en.js
+++ b/lang/en.js
@@ -17,7 +17,6 @@ export default {
 	"pause": "Pause",
 	"play": "Play",
 	"playbackSpeed": "Playback speed",
-	'playButton': "Play Button",
 	"retry": "Retry",
 	"showSearchInput": "Show search input",
 	"searchPlaceholder": "Search...",

--- a/media-player.js
+++ b/media-player.js
@@ -1333,7 +1333,7 @@ class MediaPlayer extends InternalDynamicLocalizeMixin(RtlMixin(LitElement)) {
 		if (!this.poster || this.autoplay || !this._posterVisible) return;
 
 		const playIcon = !this._loading ? html`
-			<button id="d2l-labs-media-player-video-poster-play-button" title=${this.localize('playButton')} aria-label=${this.localize('playButton')} transcript="${ifDefined(this.transcriptViewerOn ? true : undefined)}"
+			<button id="d2l-labs-media-player-video-poster-play-button" title=${this.localize('play')} aria-label=${this.localize('play')} transcript="${ifDefined(this.transcriptViewerOn ? true : undefined)}"
 				@click=${this._onVideoClick}>
 				<d2l-icon icon="tier1:play" theme="${ifDefined(this._getTheme())}"></d2l-icon>
 			</button>

--- a/media-player.js
+++ b/media-player.js
@@ -1333,7 +1333,7 @@ class MediaPlayer extends InternalDynamicLocalizeMixin(RtlMixin(LitElement)) {
 		if (!this.poster || this.autoplay || !this._posterVisible) return;
 
 		const playIcon = !this._loading ? html`
-			<button id="d2l-labs-media-player-video-poster-play-button" title="Button" transcript="${ifDefined(this.transcriptViewerOn ? true : undefined)}"
+			<button id="d2l-labs-media-player-video-poster-play-button" title=${this.localize('playButton')} aria-label=${this.localize('playButton')} transcript="${ifDefined(this.transcriptViewerOn ? true : undefined)}"
 				@click=${this._onVideoClick}>
 				<d2l-icon icon="tier1:play" theme="${ifDefined(this._getTheme())}"></d2l-icon>
 			</button>

--- a/media-player.js
+++ b/media-player.js
@@ -1333,7 +1333,7 @@ class MediaPlayer extends InternalDynamicLocalizeMixin(RtlMixin(LitElement)) {
 		if (!this.poster || this.autoplay || !this._posterVisible) return;
 
 		const playIcon = !this._loading ? html`
-			<button id="d2l-labs-media-player-video-poster-play-button" title=${this.localize('play')} aria-label=${this.localize('play')} transcript="${ifDefined(this.transcriptViewerOn ? true : undefined)}"
+			<button id="d2l-labs-media-player-video-poster-play-button" aria-label=${this.localize('play')} transcript="${ifDefined(this.transcriptViewerOn ? true : undefined)}"
 				@click=${this._onVideoClick}>
 				<d2l-icon icon="tier1:play" theme="${ifDefined(this._getTheme())}"></d2l-icon>
 			</button>

--- a/media-player.js
+++ b/media-player.js
@@ -1333,7 +1333,7 @@ class MediaPlayer extends InternalDynamicLocalizeMixin(RtlMixin(LitElement)) {
 		if (!this.poster || this.autoplay || !this._posterVisible) return;
 
 		const playIcon = !this._loading ? html`
-			<button id="d2l-labs-media-player-video-poster-play-button" transcript="${ifDefined(this.transcriptViewerOn ? true : undefined)}"
+			<button id="d2l-labs-media-player-video-poster-play-button" title="Button" transcript="${ifDefined(this.transcriptViewerOn ? true : undefined)}"
 				@click=${this._onVideoClick}>
 				<d2l-icon icon="tier1:play" theme="${ifDefined(this._getTheme())}"></d2l-icon>
 			</button>


### PR DESCRIPTION
Context: folio-app consumes the media-player component and uses it within one of our own components (video-renderer). When creating aXe tests for our video-renderer component I encountered this error:

![image](https://github.com/BrightspaceUILabs/media-player/assets/64623750/a52e696a-a3e8-4d10-a2e5-e5eebfd839e5)


And I believe that my changes will remedy this