### PR TITLE
fix: "label" should be "text"

### DIFF
--- a/media-player.js
+++ b/media-player.js
@@ -931,7 +931,7 @@ class MediaPlayer extends InternalDynamicLocalizeMixin(RtlMixin(LitElement)) {
 					><d2l-button-icon
 							icon="tier1:search"
 							id="d2l-labs-media-player-search-button"
-							label=${this.localize('showSearchInput')}
+							text=${this.localize('showSearchInput')}
 							theme="${ifDefined(theme)}"
 						></d2l-button-icon>
 						<input


### PR DESCRIPTION
Noticed this in the JavaScript errors as it's getting logged ~200,000 per month. `<d2l-button-icon>` takes a `text` attribute, not `label`.