### PR TITLE
MED-1245: Remove "false" text in settings when Download button is hidden

### DIFF
--- a/media-player.js
+++ b/media-player.js
@@ -962,7 +962,7 @@ class MediaPlayer extends InternalDynamicLocalizeMixin(RtlMixin(LitElement)) {
 								</d2l-menu-item>
 								${this._getTracksMenuView()}
 								${this._getQualityMenuView()}
-								${this.allowDownload && this._getCurrentSource() && this._getDownloadButtonView()}
+								${(this.allowDownload && this._getCurrentSource()) ? this._getDownloadButtonView() : ''}
 								<slot name="settings-menu-item"></slot>
 							</d2l-menu>
 						</d2l-dropdown-menu>


### PR DESCRIPTION
Before:

<img width="1195" alt="MED-1245 - Before" src="https://github.com/user-attachments/assets/ece29962-39e2-4930-a863-aed2cccb67ce">

After:

<img width="1197" alt="MED-1245 - After" src="https://github.com/user-attachments/assets/25b11df5-0af6-4c95-9a7d-0b9000b0e037">

Will open followup PRs in content-components to update the media-player dependency in 20.25.01 and 20.24.12.