### PR TITLE
Fixed regression for console errors if legacy videos / audio are loaded

### DIFF
--- a/media-player.js
+++ b/media-player.js
@@ -1184,6 +1184,7 @@ class MediaPlayer extends InternalDynamicLocalizeMixin(RtlMixin(LitElement)) {
 
 	_getDownloadLink() {
 		const srcUrl = this._getCurrentSource();
+		if (!srcUrl) return '';
 		if (srcUrl.startsWith('blob:')) {
 			return srcUrl;
 		}


### PR DESCRIPTION
This fixes the issue reported here: https://github.com/BrightspaceUILabs/media-player/pull/270#issuecomment-2517989292