### PR TITLE
fix: Cosmetic change to bump version (VOY-3077)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # media-player
 
+
 [![NPM version](https://img.shields.io/npm/v/@brightspace-ui-labs/media-player.svg)](https://www.npmjs.org/package/@brightspace-ui-labs/media-player)
 
 > Note: this is a ["labs" component](https://daylight.d2l.dev/developing/getting-started/component-tiers/). While functional, these tasks are prerequisites to promotion to BrightspaceUI "official" status:


### PR DESCRIPTION
Semantic release was not triggered for #295 due to a small typo in the commit title (uppercase "F" instead of "f" in "fix"). This PR makes a small cosmetic change to the README so we can merge a commit with an appropriate title.