### PR TITLE
VOY-3077: Revert "Fix: Aspect Ratio Overrides Max Height Constraint. "

### DIFF
--- a/media-player.js
+++ b/media-player.js
@@ -105,6 +105,7 @@ class MediaPlayer extends InternalDynamicLocalizeMixin(RtlMixin(LitElement)) {
 			_hovering: { type: Boolean, attribute: false },
 			_loading: { type: Boolean, attribute: false },
 			_maintainHeight: { type: Number, attribute: false },
+			_mediaContainerAspectRatio: { type: Object, attribute: false },
 			_message: { type: Object, attribute: false },
 			_muted: { type: Boolean, attribute: false },
 			_playing: { type: Boolean, attribute: false },
@@ -670,6 +671,8 @@ class MediaPlayer extends InternalDynamicLocalizeMixin(RtlMixin(LitElement)) {
 		this._volume = 1;
 		this._webVTTParser = new window.WebVTTParser();
 		this._playRequested = false;
+		this._mediaContainerAspectRatio = {
+		};
 		this.afterCaptions = [];
 		this.beforeCaptions = [];
 	}
@@ -802,6 +805,7 @@ class MediaPlayer extends InternalDynamicLocalizeMixin(RtlMixin(LitElement)) {
 			display: 'flex',
 			minHeight: this.mediaType === SOURCE_TYPES.audio ? 'min(17rem, 90vh)' : 'auto',
 			height,
+			...this._mediaContainerAspectRatio,
 		};
 		const timeStyle = {
 			fontSize: `${this._timeFontSizeRem}rem`,
@@ -1650,6 +1654,11 @@ class MediaPlayer extends InternalDynamicLocalizeMixin(RtlMixin(LitElement)) {
 	}
 
 	_onLoadedData() {
+		const media = this._media;
+		const width = media.videoWidth;
+		const height = media.videoHeight;
+		const aspectRatio = width / height;
+		this._mediaContainerAspectRatio = { 'aspect-ratio': Number.isNaN(aspectRatio) ? 'auto' : aspectRatio.toString() };
 		this._disableNativeCaptions();
 		this.dispatchEvent(new CustomEvent('loadeddata'));
 	}


### PR DESCRIPTION
Reverts BrightspaceUILabs/media-player#295

The issue was found that breaks the Media Player transcript viewer rendering in multiple places.

We can not risk deploying this change to production without fixing the transcript viewer. 
For now, we've decided to revert the changes caused by #295  

Possible fix could be, keeping the aspect-ration calculation as-is with height and width adjustments based on the `--d2l-labs-media-player-video-max-height` property.