### PR TITLE
fix: update fuse.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@brightspace-ui/core": "^3",
-        "fuse.js": "^6.4.6",
+        "fuse.js": "^7",
         "lit": "^3",
         "lodash-es": "^4.17.21",
         "parse-srt": "^1.0.0-alpha",
@@ -4515,9 +4515,10 @@
       }
     },
     "node_modules/fuse.js": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
-      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
+      "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=10"
       }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@brightspace-ui/core": "^3",
-    "fuse.js": "^6.4.6",
+    "fuse.js": "^7",
     "lit": "^3",
     "lodash-es": "^4.17.21",
     "parse-srt": "^1.0.0-alpha",


### PR DESCRIPTION
This was updated in the `@brightspace-ui/labs` version, so the conflicting versions are breaking BSI.

GAUD-7805